### PR TITLE
Fix redis pub sub and adjustment to compose

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,4 +1,5 @@
 MONGODB_URI=mongodb://localhost/db
+REDIS_URI=redis://localhost
 KEK_VERSION=KEK_VERSION_1
 
 # generate this value using `openssl rand -base64 32`

--- a/prod.yaml
+++ b/prod.yaml
@@ -3,7 +3,7 @@ services:
     image: mongo:8
     restart: always
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - .mongodb/data/db:/data/db
     environment:
@@ -25,6 +25,7 @@ services:
     restart: always
     environment:
       - MONGODB_URI=mongodb://${MONGODB_USER:-proxy}:${MONGODB_PASSWORD:-corsfix}@mongodb/db?authSource=admin
+      - REDIS_URI=redis://default:${REDIS_PASSWORD:-corsfix}@redis
       - KEK_VERSION=KEK_VERSION_1
       - KEK_VERSION_1=${KEK_VERSION_1}
       - AUTH_SECRET=${AUTH_SECRET}

--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -20,6 +20,7 @@ import { handleMetrics } from "./middleware/metrics";
 import { CorsfixRequest } from "./types/api";
 import { registerMetricShutdownHandlers } from "./lib/services/metricService";
 import { initRedis } from "./lib/services/cacheService";
+import { initPubSub } from "./lib/services/pubSubService";
 
 const PORT = 80;
 const app = new Server({
@@ -165,6 +166,7 @@ app.any("/", async (req: CorsfixRequest, res: Response) => {
 (async () => {
   await dbConnect();
   await initRedis();
+  await initPubSub();
 
   registerMetricShutdownHandlers();
   registerAppInvalidateCacheHandlers();

--- a/proxy/lib/services/applicationService.ts
+++ b/proxy/lib/services/applicationService.ts
@@ -1,7 +1,7 @@
 import { ApplicationEntity } from "../../models/ApplicationEntity";
 import { Application } from "../../types/api";
 import { CacheableMemory } from "cacheable";
-import { getRedisClient } from "./cacheService";
+import { getPubSubClient } from "./pubSubService";
 
 const applicationCache = new CacheableMemory({
   ttl: "1m",
@@ -37,14 +37,14 @@ export const getApplication = async (
 };
 
 export const registerAppInvalidateCacheHandlers = () => {
-  const redis = getRedisClient();
+  const pubSub = getPubSubClient();
 
-  redis.subscribe("app-invalidate", (err, count) => {
+  pubSub.subscribe("app-invalidate", (err, count) => {
     if (err) console.error(err);
     console.log(`Subscribed to ${count} channels.`);
   });
 
-  redis.on("message", (channel, message) => {
+  pubSub.on("message", (channel, message) => {
     switch (channel) {
       case "app-invalidate":
         try {

--- a/proxy/lib/services/pubSubService.ts
+++ b/proxy/lib/services/pubSubService.ts
@@ -1,0 +1,15 @@
+import Redis from "ioredis";
+
+const REDIS_URI = process.env.REDIS_URI;
+if (!REDIS_URI) {
+  throw new Error("Please define the REDIS_URI environment variable");
+}
+const pubSubClient = new Redis(REDIS_URI, { lazyConnect: true });
+
+export const initPubSub = async () => {
+  await pubSubClient.connect();
+};
+
+export const getPubSubClient = () => {
+  return pubSubClient;
+};


### PR DESCRIPTION
- use different redis connection for cache and pubsub
- add redis uri in both .env.example and prod.yaml
- minor fix compose, to only allow localhost (mongo)