### PR TITLE
Add support request path input url

### DIFF
--- a/proxy/index.ts
+++ b/proxy/index.ts
@@ -7,11 +7,13 @@ import {
 } from "./lib/util";
 import dbConnect from "./lib/dbConnect";
 import "dotenv/config";
-import { getApplication, registerAppInvalidateCacheHandlers } from "./lib/services/applicationService";
+import {
+  getApplication,
+  registerAppInvalidateCacheHandlers,
+} from "./lib/services/applicationService";
 import {
   validateOriginHeader,
   validatePayloadSize,
-  validateQueryParams,
   validateUrl,
 } from "./middleware/validation";
 import { handlePreflight } from "./middleware/preflight";
@@ -44,18 +46,17 @@ app.use("/", (req: Request, res: Response, next: MiddlewareNext) => {
   next();
 });
 
-app.use("/", validateQueryParams);
-app.use("/", handlePreflight);
-
+app.use("/", handleMetrics);
 app.use("/", validatePayloadSize);
 
 app.use("/", validateOriginHeader);
 app.use("/", validateUrl);
 
-app.use("/", handleMetrics);
+app.use("/", handlePreflight);
+
 app.use("/", handleRateLimit);
 
-app.any("/", async (req: CorsfixRequest, res: Response) => {
+app.any("/*", async (req: CorsfixRequest, res: Response) => {
   const { url: targetUrl } = getProxyRequest(req);
   const origin = req.header("Origin");
 

--- a/proxy/lib/util.ts
+++ b/proxy/lib/util.ts
@@ -40,7 +40,7 @@ export function isRegisteredOrigin(origin: string, url: string): boolean {
 }
 
 const processUrlString = (urlString: string): URL => {
-  const processedUrl = urlString.startsWith("http")
+  const processedUrl = /^https?:\/\//.test(urlString)
     ? urlString
     : `https://${urlString}`;
   return new URL(decodeURIComponent(processedUrl));

--- a/proxy/lib/util.ts
+++ b/proxy/lib/util.ts
@@ -39,27 +39,25 @@ export function isRegisteredOrigin(origin: string, url: string): boolean {
   );
 }
 
+const processUrlString = (urlString: string): URL => {
+  const processedUrl = urlString.startsWith("http")
+    ? urlString
+    : `https://${urlString}`;
+  return new URL(decodeURIComponent(processedUrl));
+};
+
 export const getProxyRequest = (req: Request): ProxyRequest => {
-  if (req.path != "/") {
-    let inputUrl = req.path.substring(1);
-    if (!inputUrl.startsWith("http")) {
-      inputUrl = "https://" + inputUrl;
-    }
-    return {
-      url: new URL(decodeURIComponent(inputUrl)),
-    };
+  let inputUrl: string;
+
+  if (req.path !== "/") {
+    inputUrl = req.path.substring(1);
+  } else if ("url" in req.query_parameters) {
+    inputUrl = req.query_parameters.url;
+  } else {
+    inputUrl = req.path_query;
   }
 
-  const params = req.query_parameters;
-  if ("url" in params) {
-    return {
-      url: new URL(decodeURIComponent(params.url)),
-    };
-  } else {
-    return {
-      url: new URL(decodeURIComponent(req.path_query)),
-    };
-  }
+  return { url: processUrlString(inputUrl) };
 };
 
 export const getPreviousMidnightEpoch = (): number => {

--- a/proxy/lib/util.ts
+++ b/proxy/lib/util.ts
@@ -40,8 +40,17 @@ export function isRegisteredOrigin(origin: string, url: string): boolean {
 }
 
 export const getProxyRequest = (req: Request): ProxyRequest => {
-  const params = req.query_parameters;
+  if (req.path != "/") {
+    let inputUrl = req.path.substring(1);
+    if (!inputUrl.startsWith("http")) {
+      inputUrl = "https://" + inputUrl;
+    }
+    return {
+      url: new URL(decodeURIComponent(inputUrl)),
+    };
+  }
 
+  const params = req.query_parameters;
   if ("url" in params) {
     return {
       url: new URL(decodeURIComponent(params.url)),

--- a/proxy/middleware/preflight.ts
+++ b/proxy/middleware/preflight.ts
@@ -19,10 +19,11 @@ export const handlePreflight = (
     }
 
     const requestHeaders = req.header("Access-Control-Request-Headers");
-    if (IS_CLOUD && requestHeaders) {
+    if (requestHeaders) {
       res.header("Access-Control-Allow-Headers", requestHeaders);
 
       if (
+        IS_CLOUD &&
         requestHeaders
           .split(",")
           .map((h) => h.trim().toLowerCase())

--- a/proxy/middleware/ratelimit.ts
+++ b/proxy/middleware/ratelimit.ts
@@ -103,10 +103,6 @@ export const handleRateLimit = async (req: CorsfixRequest, res: Response) => {
   });
 
   if (!isAllowed) {
-    return res
-      .status(429)
-      .end(
-        "Corsfix: Too Many Requests. Check the documentation for throughput. (https://corsfix.com/docs/cors-proxy/throughput)"
-      );
+    return res.status(429).end("Corsfix: Too Many Requests.");
   }
 };

--- a/proxy/middleware/validation.ts
+++ b/proxy/middleware/validation.ts
@@ -36,8 +36,13 @@ export const validateUrl = (
 
   try {
     const proxyReq = getProxyRequest(req);
+
     if (!["http:", "https:"].includes(proxyReq.url.protocol)) {
       throw new Error("Invalid protocol. Only HTTP and HTTPS are allowed.");
+    }
+
+    if (!proxyReq.url.hostname.includes(".")) {
+      throw new Error("Invalid hostname. TLD is required.");
     }
   } catch (e) {
     res.header("X-Robots-Tag", "noindex, nofollow");

--- a/proxy/middleware/validation.ts
+++ b/proxy/middleware/validation.ts
@@ -2,20 +2,6 @@ import { MiddlewareNext, Request, Response } from "hyper-express";
 import { getProxyRequest } from "../lib/util";
 import { CorsfixRequest } from "../types/api";
 
-export const validateQueryParams = (
-  req: Request,
-  res: Response,
-  next: MiddlewareNext
-) => {
-  if (!req.path_query) {
-    res.status(301);
-    res.header("Cache-Control", "public, max-age=3600");
-    res.header("Location", "https://corsfix.com");
-    res.end();
-  }
-  next();
-};
-
 export const validateOriginHeader = (
   req: CorsfixRequest,
   res: Response,
@@ -41,6 +27,13 @@ export const validateUrl = (
   res: Response,
   next: MiddlewareNext
 ) => {
+  if (!req.path_query && req.path == "/") {
+    res.status(301);
+    res.header("Cache-Control", "public, max-age=3600");
+    res.header("Location", "https://corsfix.com");
+    res.end();
+  }
+
   try {
     const proxyReq = getProxyRequest(req);
     if (!["http:", "https:"].includes(proxyReq.url.protocol)) {

--- a/proxy/tsconfig.json
+++ b/proxy/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2022"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */


### PR DESCRIPTION
Closes #4 

- add using direct path `https://proxy/<url>` without the query string question mark
- support using URL without protocol, defaults to https
- improve url validation and fix timeout error
- minor fix preflight handler, reordering middleware, ratelimit error