### PR TITLE
Remove registered origin logic

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -1,9 +1,6 @@
 name: App CI
 
 on:
-  push:
-    paths:
-      - "app/**"
   pull_request:
     paths:
       - "app/**"

--- a/.github/workflows/ci-proxy.yml
+++ b/.github/workflows/ci-proxy.yml
@@ -1,9 +1,6 @@
 name: Proxy CI
 
 on:
-  push:
-    paths:
-      - "proxy/**"
   pull_request:
     paths:
       - "proxy/**"

--- a/proxy/lib/util.ts
+++ b/proxy/lib/util.ts
@@ -1,5 +1,4 @@
 import { Request } from "hyper-express";
-import { registeredOrigins } from "free-cors-proxy";
 import {
   EnvHttpProxyAgent,
   fetch,
@@ -28,15 +27,6 @@ export function isLocalOrigin(origin: string): boolean {
     /^https:\/\/app\.corsfix\.com$/,
   ];
   return localOriginPatterns.some((pattern) => pattern.test(origin));
-}
-
-export function isRegisteredOrigin(origin: string, url: string): boolean {
-  return (
-    origin in registeredOrigins &&
-    Array.from(registeredOrigins[origin]).some(
-      (pattern) => url.includes(pattern) || pattern == "*"
-    )
-  );
 }
 
 export const isValidUrl = (url: string) => {

--- a/proxy/middleware/ratelimit.ts
+++ b/proxy/middleware/ratelimit.ts
@@ -1,10 +1,5 @@
 import { Response } from "hyper-express";
-import {
-  getProxyRequest,
-  getRpmByProductId,
-  isLocalOrigin,
-  isRegisteredOrigin,
-} from "../lib/util";
+import { getProxyRequest, getRpmByProductId, isLocalOrigin } from "../lib/util";
 import { CorsfixRequest, RateLimitConfig } from "../types/api";
 import { getApplication } from "../lib/services/applicationService";
 import { getActiveSubscription } from "../lib/services/subscriptionService";
@@ -52,11 +47,6 @@ export const handleRateLimit = async (req: CorsfixRequest, res: Response) => {
       key: req.header("x-real-ip") || req.ip,
       rpm: 180,
       local: true,
-    };
-  } else if (isRegisteredOrigin(origin, url.href)) {
-    rateLimitConfig = {
-      key: origin,
-      rpm: 60,
     };
   } else {
     const application = await getApplication(domain);

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -15,7 +15,6 @@
     "cron": "^3.1.8",
     "dotenv": "^16.4.5",
     "fetch-socks": "^1.3.2",
-    "free-cors-proxy": "github:corsfix/free-cors-proxy#v1.0.11",
     "hyper-express": "^6.17.2",
     "ioredis": "^5.6.0",
     "ipaddr.js": "^2.2.0",

--- a/proxy/pnpm-lock.yaml
+++ b/proxy/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       fetch-socks:
         specifier: ^1.3.2
         version: 1.3.2
-      free-cors-proxy:
-        specifier: github:corsfix/free-cors-proxy#v1.0.11
-        version: oss@https://codeload.github.com/corsfix/free-cors-proxy/tar.gz/638ac1d2413d5b5a3cecbcae357344501a37bc6a
       hyper-express:
         specifier: ^6.17.2
         version: 6.17.3
@@ -72,10 +69,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.16.2)(@vitest/ui@3.2.4)(msw@2.11.0(@types/node@22.16.2)(typescript@5.8.3))(tsx@4.20.3)
-
-  ..: {}
-
-  ../app: {}
 
 packages:
 
@@ -1002,10 +995,6 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-
-  oss@https://codeload.github.com/corsfix/free-cors-proxy/tar.gz/638ac1d2413d5b5a3cecbcae357344501a37bc6a:
-    resolution: {tarball: https://codeload.github.com/corsfix/free-cors-proxy/tar.gz/638ac1d2413d5b5a3cecbcae357344501a37bc6a}
-    version: 1.0.6
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -2287,8 +2276,6 @@ snapshots:
       undefsafe: 2.0.5
 
   normalize-path@3.0.0: {}
-
-  oss@https://codeload.github.com/corsfix/free-cors-proxy/tar.gz/638ac1d2413d5b5a3cecbcae357344501a37bc6a: {}
 
   outvariant@1.4.3:
     optional: true


### PR DESCRIPTION
This change removes the specific logic for sponsorship registered origin.

To be clear, we are not removing sponsorship, but we are shifting towards sponsoring accounts instead of specific websites.