### PR TITLE
Init use own domain for selfhost

### DIFF
--- a/app/app/get-started/page.tsx
+++ b/app/app/get-started/page.tsx
@@ -105,7 +105,9 @@ export default async function GetStarted() {
                     <code lang="javascript">
                       {`// Example usage with fetch
 const url = "https://api.example.com"
-fetch("https://proxy.corsfix.com/?" + url);`}
+fetch("https://proxy.${
+                        IS_CLOUD ? "corsfix.com" : process.env.DOMAIN
+                      }/?" + url);`}
                     </code>
                   </pre>
                 </div>

--- a/app/app/playground/layout.tsx
+++ b/app/app/playground/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import Page from "./page";
+import { IS_CLOUD } from "@/config/constants";
 
 export const dynamic = "force-dynamic";
 
@@ -7,5 +8,5 @@ export const metadata: Metadata = {
   title: "Playground | Corsfix Dashboard",
 };
 export default function PageLayout() {
-  return <Page />;
+  return <Page IS_CLOUD={IS_CLOUD} DOMAIN={process.env.DOMAIN as string} />;
 }

--- a/app/config/constants.ts
+++ b/app/config/constants.ts
@@ -90,3 +90,4 @@ export const freeTierLimit: FreeTierLimit = {
 
 export const config = configList[ENV];
 export const IS_CLOUD = process.env.CLOUD === "true";
+export const IS_SELFHOST = !IS_CLOUD;


### PR DESCRIPTION
Fixes #30 

- accept `DOMAIN` in dashboard
- use selfhost domain for getting started and playground
- disable region tab for selfhost