### PR TITLE
Return custom header for set-cookie

### DIFF
--- a/proxy/app.ts
+++ b/proxy/app.ts
@@ -126,10 +126,12 @@ app.any("/*", async (req: CorsfixRequest, res: Response) => {
 
     responseHeaders.delete("transfer-encoding");
 
-    const setCookie = responseHeaders.get("set-cookie");
-    if (setCookie) {
+    const setCookies = responseHeaders.getSetCookie();
+    if (setCookies.length > 0) {
       responseHeaders.delete("set-cookie");
-      responseHeaders.set("x-corsfix-set-cookie", setCookie);
+      for (const cookie of setCookies) {
+        responseHeaders.append("x-corsfix-set-cookie", cookie);
+      }
     }
 
     if (req.ctx_cached_request && !callback) {


### PR DESCRIPTION
- use `x-corsfix-set-cookie` instead of outright deleting cookie, this is a middle ground 
  - where we don't unintentionally leak cookies between origin because of browser behaviour (when returning `set-cookie`)
  - while still allowing users to read the cookie value, which they will have to manually store and/or send
- remove `set-cookie2` as it's deprecated 