### PR TITLE
Enable CORS headers for error responses

### DIFF
--- a/proxy/app.ts
+++ b/proxy/app.ts
@@ -30,6 +30,8 @@ export const app = new Server({
 app.set_error_handler((_: Request, res: Response, error: Error) => {
   console.error("Uncaught error occurred.", error);
   res.header("X-Corsfix-Status", "uncaught_error", true);
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Expose-Headers", "*");
   res.status(500).end("Corsfix: Uncaught error occurred.");
 });
 
@@ -153,6 +155,8 @@ app.any("/*", async (req: CorsfixRequest, res: Response) => {
     const { name, message, cause } = error as Error;
     if (name === "AbortError" || name === "TimeoutError") {
       res.header("X-Corsfix-Status", "timeout", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       res
         .status(504)
         .end(
@@ -161,15 +165,21 @@ app.any("/*", async (req: CorsfixRequest, res: Response) => {
     } else if (message === "fetch failed") {
       if ((cause as any).code === "ENOTFOUND") {
         res.header("X-Corsfix-Status", "target_not_found", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         res.status(404).end("Corsfix: Target URL not found.");
       } else {
         console.error("Fetch error occurred.", error);
         res.header("X-Corsfix-Status", "target_unreachable", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         res.status(502).end("Corsfix: Unable to reach target URL.");
       }
     } else {
       console.error("Unknown error occurred.", error);
       res.header("X-Corsfix-Status", "unknown_error", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       res.status(500).end("Corsfix: Unknown error occurred.");
     }
   }
@@ -218,6 +228,8 @@ const textOnlyHandler = async (
     contentLength > ONE_MEGABYTE
   ) {
     res.header("X-Corsfix-Status", "response_too_large", true);
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Expose-Headers", "*");
     return res.status(400).end("Corsfix: Text response size too large.");
   }
 
@@ -235,6 +247,8 @@ const textOnlyHandler = async (
       // Check if we exceeded size limit
       if (bytes > ONE_MEGABYTE) {
         res.header("X-Corsfix-Status", "response_too_large", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(400)
           .end("Corsfix: Response size too large (max 1MB).");
@@ -270,6 +284,8 @@ const textOnlyHandler = async (
       return res.send(compression.compressed);
     } catch (error) {
       res.header("X-Corsfix-Status", "response_not_text", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       return res.status(400).end("Corsfix: Response is not valid text.");
     }
   }
@@ -298,6 +314,8 @@ const jsonpHandler = async (
       contentLength > ONE_MEGABYTE
     ) {
       res.header("X-Corsfix-Status", "response_too_large", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       return res
         .status(400)
         .end("Corsfix: Response size too large for JSONP (max 1MB).");
@@ -313,6 +331,8 @@ const jsonpHandler = async (
       // Check if we exceeded size limit
       if (bytes > ONE_MEGABYTE) {
         res.header("X-Corsfix-Status", "response_too_large", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(400)
           .end("Corsfix: Response size too large for JSONP (max 1MB).");

--- a/proxy/middleware/access.ts
+++ b/proxy/middleware/access.ts
@@ -33,6 +33,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       user = await getUserByApiKey(apiKey);
       if (!user) {
         res.header("X-Corsfix-Status", "invalid_api_key", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res.status(403).end("Corsfix: Invalid API key.");
       }
 
@@ -41,6 +43,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       const application = await getApplication(origin_domain);
       if (!application) {
         res.header("X-Corsfix-Status", "domain_not_registered", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(403)
           .end(
@@ -49,6 +53,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       }
       if (!isDomainAllowed(target_domain, application.target_domains)) {
         res.header("X-Corsfix-Status", "target_not_allowed", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(403)
           .end(
@@ -59,6 +65,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       user = await getUser(application.user_id);
       if (!user) {
         res.header("X-Corsfix-Status", "user_not_found", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res.status(403).end(`Corsfix: User not found!`);
       }
       req.ctx_user_id = application.user_id;
@@ -75,6 +83,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       );
       if (!product) {
         res.header("X-Corsfix-Status", "invalid_subscription", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(400)
           .end(
@@ -88,6 +98,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       const metricsMtd = await getMonthToDateMetrics(req.ctx_user_id);
       if (metricsMtd.bytes >= trialLimit.bytes) {
         res.header("X-Corsfix-Status", "trial_limit_reached", true);
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Access-Control-Expose-Headers", "*");
         return res
           .status(403)
           .end(
@@ -96,6 +108,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       }
     } else {
       res.header("X-Corsfix-Status", "trial_expired", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       return res
         .status(403)
         .end(
@@ -121,6 +135,8 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
 
   if (!isAllowed) {
     res.header("X-Corsfix-Status", "rate_limited", true);
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Expose-Headers", "*");
     return res.status(429).end("Corsfix: Too Many Requests.");
   }
 };

--- a/proxy/middleware/validation.ts
+++ b/proxy/middleware/validation.ts
@@ -25,6 +25,8 @@ export const validateOriginHeader = (
   } else {
     res.header("X-Robots-Tag", "noindex, nofollow");
     res.header("X-Corsfix-Status", "invalid_origin", true);
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Expose-Headers", "*");
     return res
       .status(400)
       .end(
@@ -48,6 +50,8 @@ export const validateJsonpRequest = (
       req.ctx_origin_domain = referrerUrl.hostname;
     } else {
       res.header("X-Corsfix-Status", "invalid_referer", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       return res
         .status(400)
         .end(
@@ -88,6 +92,8 @@ export const validateTargetUrl = (
   } catch (e) {
     res.header("X-Robots-Tag", "noindex, nofollow");
     res.header("X-Corsfix-Status", "invalid_url", true);
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Expose-Headers", "*");
     return res
       .status(400)
       .end(
@@ -107,6 +113,8 @@ export const validatePayloadSize = (
     const contentLength = parseInt(contentLengthHeader, 10);
     if (!isNaN(contentLength) && contentLength > 5 * 1024 * 1024) {
       res.header("X-Corsfix-Status", "payload_too_large", true);
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Expose-Headers", "*");
       return res
         .status(413)
         .end(


### PR DESCRIPTION
- set ACAO and ACEH to * for errors
- the reasoning here is to let user see the error response from the proxy
- previously it will just return CORS error, which is unhelpful because they can't see the message