### PR TITLE
Bump timeout

### DIFF
--- a/proxy/app.ts
+++ b/proxy/app.ts
@@ -201,15 +201,14 @@ const corsHandler = async (
       },
     });
 
-    const readable = Readable.from(apiResponse.body).pipe(counter);
-    readable.on("error", (error) => {
-      console.error("Stream error:", error);
-    });
+    const source = Readable.from(apiResponse.body);
+    const readable = source.pipe(counter);
+    source.on("error", (err) => readable.destroy(err));
+    readable.on("error", () => {});
     try {
       await res.stream(readable, contentLength);
     } catch (error) {
       console.error("Error while streaming response:", error);
-      // Ensure the response is properly terminated on error
       res.end();
     } finally {
       req.ctx_bytes = bytes;


### PR DESCRIPTION
- bump timeout 20s -> 60s
- this is temporary mitigation for large files download
- the point of time out being there in the first place is to prevent the request hanging and eating up server resources
- we have to revisit this later, as to only have timeout for these 2 cases
  - when first request = fetching headers, making sure it's not hanging here
  - and during streaming, this will be a running timeout thing, if it doesn't send data within certain window, it is then hanging
- also add error event listener for readable stream 