### PR TITLE
Add support for custom tls cert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ DISABLE_SIGNUP=false
 
 # Rate limit (requests per minute) for self-hosted instances (default: 180)
 RPM=180
+
+# Custom TLS certificates (optional)
+# Set paths to your cert and key files, then uncomment the tls lines in Caddyfile
+TLS_CERT=
+TLS_KEY=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,9 @@
 {$APP_DOMAIN:app.localhost} {
     reverse_proxy app:3000
+    # tls /certs/cert.pem /certs/key.pem
 }
 
 {$PROXY_DOMAIN:proxy.localhost} {
     reverse_proxy proxy:80
+    # tls /certs/cert.pem /certs/key.pem
 }

--- a/prod.yaml
+++ b/prod.yaml
@@ -52,6 +52,8 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - .caddy/data:/data
       - .caddy/config:/config
+      - ${TLS_CERT:-/dev/null}:/certs/cert.pem:ro
+      - ${TLS_KEY:-/dev/null}:/certs/key.pem:ro
     environment:
       - APP_DOMAIN=${APP_DOMAIN}
       - PROXY_DOMAIN=${PROXY_DOMAIN}


### PR DESCRIPTION
#58 

this change allow for custom TLS cert, just supply the paths for your cert and key, then uncomment the Caddyfile tls config