### PR TITLE
Add support custom port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ DISABLE_SIGNUP=false
 # Rate limit (requests per minute) for self-hosted instances (default: 180)
 RPM=180
 
+# Custom ports (optional, if 80/443 are already in use)
+HTTP_PORT=80
+HTTPS_PORT=443
+
 # Custom TLS certificates (optional)
 # Set paths to your cert and key files, then uncomment the tls lines in Caddyfile
 TLS_CERT=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,13 @@
+# HTTP to HTTPS redirects
+http://{$APP_DOMAIN:app.localhost} {
+    redir https://{host}:{$HTTPS_PORT:443}{uri} permanent
+}
+
+http://{$PROXY_DOMAIN:proxy.localhost} {
+    redir https://{host}:{$HTTPS_PORT:443}{uri} permanent
+}
+
+# HTTPS
 {$APP_DOMAIN:app.localhost} {
     reverse_proxy app:3000
     # tls /certs/cert.pem /certs/key.pem

--- a/app/app/get-started/page.tsx
+++ b/app/app/get-started/page.tsx
@@ -13,7 +13,7 @@ import { ExternalLink, NotepadText } from "lucide-react";
 import { ApiKeyButton } from "@/components/api-key-button";
 import type { Metadata } from "next";
 import { auth } from "@/auth";
-import { getTrialEnds, isTrialActive } from "@/lib/utils";
+import { getProxyDomain, getTrialEnds, isTrialActive } from "@/lib/utils";
 import { IS_CLOUD } from "@/config/constants";
 
 export const metadata: Metadata = {
@@ -125,7 +125,7 @@ export default async function GetStarted() {
                       {`// Example usage with fetch
 const url = "https://api.example.com"
 fetch("https://${
-                        IS_CLOUD ? "proxy.corsfix.com" : process.env.PROXY_DOMAIN
+                        IS_CLOUD ? "proxy.corsfix.com" : getProxyDomain()
                       }/?" + url);`}
                     </code>
                   </pre>

--- a/app/app/playground/page.tsx
+++ b/app/app/playground/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 import { IS_CLOUD } from "@/config/constants";
 import Playground from "@/components/Playground";
+import { getProxyDomain } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -9,6 +10,6 @@ export const metadata: Metadata = {
 };
 export default function PlaygroundPage() {
   return (
-    <Playground isCloud={IS_CLOUD} proxyDomain={process.env.PROXY_DOMAIN as string} />
+    <Playground isCloud={IS_CLOUD} proxyDomain={getProxyDomain()} />
   );
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -155,6 +155,12 @@ export function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).substr(2);
 }
 
+export const getProxyDomain = (): string => {
+  const domain = process.env.PROXY_DOMAIN || "";
+  // Strip default HTTPS port if present
+  return domain.replace(/:443$/, "");
+};
+
 export const isLocalDomain = (domain: string): boolean => {
   const localDomains = [
     "localhost",

--- a/prod.yaml
+++ b/prod.yaml
@@ -31,8 +31,8 @@ services:
       - KEK_VERSION_1=${KEK_VERSION_1}
       - AUTH_SECRET=${AUTH_SECRET}
       - AUTH_TRUST_HOST=true
-      - AUTH_URL=https://${APP_DOMAIN}
-      - PROXY_DOMAIN=${PROXY_DOMAIN}
+      - AUTH_URL=https://${APP_DOMAIN}:${HTTPS_PORT:-443}
+      - PROXY_DOMAIN=${PROXY_DOMAIN}:${HTTPS_PORT:-443}
   proxy:
     image: ghcr.io/corsfix/corsfix-proxy:latest
     pull_policy: always
@@ -46,8 +46,8 @@ services:
     image: caddy:2-alpine
     restart: always
     ports:
-      - "80:80"
-      - "443:443"
+      - "${HTTP_PORT:-80}:80"
+      - "${HTTPS_PORT:-443}:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - .caddy/data:/data
@@ -57,6 +57,7 @@ services:
     environment:
       - APP_DOMAIN=${APP_DOMAIN}
       - PROXY_DOMAIN=${PROXY_DOMAIN}
+      - HTTPS_PORT=${HTTPS_PORT:-443}
     depends_on:
       - app
       - proxy


### PR DESCRIPTION
#58 

- add custom port support via `HTTP_PORT` and `HTTPS_PORT`
- we strictly use https here, the http is only there for redirecting to the https port
- caddy logic to redirect http to correct https port (otherwise it will redirect to default)
- logic in dashboard to clean if its using default https port