### PR TITLE
Use path instead of full callback url for email login

### DIFF
--- a/app/app/api/auth/verify/route.ts
+++ b/app/app/api/auth/verify/route.ts
@@ -9,19 +9,18 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function parseCallbackUrl(encoded: string, baseUrl: string): string | null {
+function decodePath(encoded: string): string | null {
   try {
     const decoded = Buffer.from(encoded, "base64").toString("utf-8");
-    const parsed = new URL(decoded, baseUrl);
-    return parsed.origin === baseUrl ? parsed.toString() : null;
+    return decoded.startsWith("/api/auth/callback/") ? decoded : null;
   } catch {
     return null;
   }
 }
 
 export async function GET(request: NextRequest) {
-  const callbackUrl = request.nextUrl.searchParams.get("callbackUrl");
-  const safeUrl = callbackUrl && parseCallbackUrl(callbackUrl, request.nextUrl.origin);
+  const encodedPath = request.nextUrl.searchParams.get("path");
+  const safeUrl = encodedPath && decodePath(encodedPath);
 
   if (!safeUrl) {
     return new Response("Invalid verification link.", { status: 400 });

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -41,9 +41,10 @@ const cloudProviders = [
 
       let interstitialUrl = url;
       try {
-        const baseUrl = new URL(url).origin;
-        const encodedCallback = encodeURIComponent(Buffer.from(url).toString("base64"));
-        interstitialUrl = `${baseUrl}/api/auth/verify?callbackUrl=${encodedCallback}`;
+        const parsed = new URL(url);
+        const path = parsed.pathname + parsed.search;
+        const encodedPath = Buffer.from(path).toString("base64");
+        interstitialUrl = `${parsed.origin}/api/auth/verify?path=${encodedPath}`;
       } catch {
         // Fallback to the original URL if parsing fails to avoid unexpected crashes.
       }


### PR DESCRIPTION
- simplify logic to use path instead of full url