### PR TITLE
Improve text only handling

### DIFF
--- a/proxy/app.ts
+++ b/proxy/app.ts
@@ -20,7 +20,6 @@ import { Readable, Transform } from "stream";
 
 import "dotenv/config";
 
-const TEXT_ONLY = process.env.TEXT_ONLY === "true";
 const ONE_MEGABYTE = 1024 * 1024;
 
 const decoder = new TextDecoder("utf-8", { fatal: true });
@@ -110,7 +109,8 @@ app.any("/*", async (req: CorsfixRequest, res: Response) => {
       ));
     }
 
-    const enableDecompression = !!(callback || TEXT_ONLY);
+    const textOnly = req.ctx_text_only;
+    const enableDecompression = !!(callback || textOnly);
     let apiResponse = await proxyRequest(processedUrl, {
       method: req.method,
       headers: processedHeaders,
@@ -152,7 +152,7 @@ app.any("/*", async (req: CorsfixRequest, res: Response) => {
 
     if (callback) {
       jsonpHandler(req, res, callback, apiResponse, responseHeaders);
-    } else if (TEXT_ONLY) {
+    } else if (textOnly) {
       textOnlyHandler(req, res, apiResponse, responseHeaders);
     } else {
       corsHandler(req, res, apiResponse, responseHeaders);

--- a/proxy/config/constants.ts
+++ b/proxy/config/constants.ts
@@ -22,3 +22,5 @@ const parseRPM = (value: string | undefined): number => {
 };
 
 export const SELFHOST_RPM = parseRPM(process.env.RPM);
+
+export const TEXT_ONLY_HOSTNAME = process.env.TEXT_ONLY_HOSTNAME;

--- a/proxy/errors.ts
+++ b/proxy/errors.ts
@@ -8,6 +8,7 @@ export type CorsfixError =
   | "invalid_subscription"
   | "invalid_url"
   | "payload_too_large"
+  | "plan_mismatch"
   | "rate_limited"
   | "response_not_text"
   | "response_too_large"
@@ -66,6 +67,13 @@ const errorDefinitions: Record<CorsfixError, ErrorDefinition> = {
     message: "The target URL is invalid or malformed",
     if_you_are_admin:
       "Check the URL format - it must be a valid HTTP/HTTPS URL",
+    if_you_are_user: "Please contact the website owner about this issue",
+  },
+  plan_mismatch: {
+    status: 403,
+    message: "Your plan does not match this proxy endpoint",
+    if_you_are_admin:
+      "Check that you are using the correct proxy URL for your plan",
     if_you_are_user: "Please contact the website owner about this issue",
   },
   payload_too_large: {

--- a/proxy/index.test.ts
+++ b/proxy/index.test.ts
@@ -1,10 +1,23 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { request } from "undici";
 import { app } from "./app";
 import * as apiKeyService from "./lib/services/apiKeyService";
 import * as configService from "./lib/config";
 import * as metricService from "./lib/services/metricService";
 
 const PORT = 8090;
+const TEXT_ONLY_HOST = "lite.test.local";
+
+// Mock constants to enable cloud mode and set text-only hostname
+vi.mock("./config/constants", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./config/constants")>();
+  return {
+    ...original,
+    IS_CLOUD: true,
+    IS_SELFHOST: false,
+    TEXT_ONLY_HOSTNAME: "lite.test.local",
+  };
+});
 
 // Mock getUserByApiKey
 vi.spyOn(apiKeyService, "getUserByApiKey").mockImplementation(
@@ -14,6 +27,14 @@ vi.spyOn(apiKeyService, "getUserByApiKey").mockImplementation(
         id: "test-user-id",
         subscription_active: true,
         subscription_product_id: "prod_123",
+        trial_ends_at: new Date("2099-01-01"),
+      };
+    }
+    if (apiKey === "cfx_textonly_test_key") {
+      return {
+        id: "test-textonly-user-id",
+        subscription_active: true,
+        subscription_product_id: "prod_textonly",
         trial_ends_at: new Date("2099-01-01"),
       };
     }
@@ -29,6 +50,13 @@ vi.spyOn(configService, "getConfig").mockReturnValue({
       name: "Test Product",
       rpm: 1000,
       rateLimitKey: "user_id",
+    },
+    {
+      id: "prod_textonly",
+      name: "Test TextOnly Product",
+      rpm: 600,
+      rateLimitKey: "user_id",
+      textOnly: true,
     },
   ],
 });
@@ -295,5 +323,57 @@ describe("API Key authentication", () => {
     expect(result.headers.get("Access-Control-Allow-Origin")).toBe(origin);
     expect(result.headers.get("Access-Control-Allow-Headers")).toBe("x-corsfix-key");
     expect(result.headers.get("X-Corsfix-Status")).toBe("preflight");
+  });
+});
+
+describe("Text-only mode", () => {
+  test("text-only plan + text-only hostname succeeds with text response", async () => {
+    const targetUrl = `https://httpbin.agrd.workers.dev/get`;
+    const result = await request(`http://127.0.0.1:${PORT}/?${targetUrl}`, {
+      headers: {
+        "x-corsfix-key": "cfx_textonly_test_key",
+        host: TEXT_ONLY_HOST,
+      },
+    });
+
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["x-corsfix-status"]).toBe("success");
+  });
+
+  test("text-only plan + standard hostname returns plan_mismatch", async () => {
+    const targetUrl = `https://httpbin.agrd.workers.dev/get`;
+    const result = await request(`http://127.0.0.1:${PORT}/?${targetUrl}`, {
+      headers: {
+        "x-corsfix-key": "cfx_textonly_test_key",
+      },
+    });
+
+    expect(result.statusCode).toBe(403);
+    expect(result.headers["x-corsfix-status"]).toBe("plan_mismatch");
+  });
+
+  test("standard plan + text-only hostname returns plan_mismatch", async () => {
+    const targetUrl = `https://httpbin.agrd.workers.dev/get`;
+    const result = await request(`http://127.0.0.1:${PORT}/?${targetUrl}`, {
+      headers: {
+        "x-corsfix-key": "cfx_valid_test_key",
+        host: TEXT_ONLY_HOST,
+      },
+    });
+
+    expect(result.statusCode).toBe(403);
+    expect(result.headers["x-corsfix-status"]).toBe("plan_mismatch");
+  });
+
+  test("text-only rejects binary response", async () => {
+    const targetUrl = `https://httpbin.agrd.workers.dev/image/png`;
+    const result = await request(`http://127.0.0.1:${PORT}/?${targetUrl}`, {
+      headers: {
+        "x-corsfix-key": "cfx_textonly_test_key",
+        host: TEXT_ONLY_HOST,
+      },
+    });
+
+    expect(result.headers["x-corsfix-status"]).toBe("response_not_text");
   });
 });

--- a/proxy/lib/config.ts
+++ b/proxy/lib/config.ts
@@ -6,6 +6,7 @@ export interface Product {
   name: string;
   rpm: number;
   rateLimitKey?: "ip" | "user_id";
+  textOnly?: boolean;
 }
 
 interface Config {

--- a/proxy/middleware/access.ts
+++ b/proxy/middleware/access.ts
@@ -9,13 +9,11 @@ import { CorsfixRequest, RateLimitConfig } from "../types/api";
 import { getApplication } from "../lib/services/applicationService";
 import { getUserByApiKey } from "../lib/services/apiKeyService";
 import { checkRateLimit } from "../lib/services/ratelimitService";
-import { IS_SELFHOST, SELFHOST_RPM, trialLimit } from "../config/constants";
+import { IS_SELFHOST, SELFHOST_RPM, TEXT_ONLY_HOSTNAME, trialLimit } from "../config/constants";
 import { getUser } from "../lib/services/userService";
 import { getMonthToDateMetrics } from "../lib/services/metricService";
 import { getConfig } from "../lib/config";
 import { sendCorsfixError } from "../errors";
-
-const TEXT_ONLY_HOSTNAME = process.env.TEXT_ONLY_HOSTNAME;
 
 const isTextOnlyRequest = (req: CorsfixRequest): boolean => {
   if (!TEXT_ONLY_HOSTNAME) return false;

--- a/proxy/middleware/access.ts
+++ b/proxy/middleware/access.ts
@@ -15,10 +15,24 @@ import { getMonthToDateMetrics } from "../lib/services/metricService";
 import { getConfig } from "../lib/config";
 import { sendCorsfixError } from "../errors";
 
+const TEXT_ONLY_HOSTNAME = process.env.TEXT_ONLY_HOSTNAME;
+
+const isTextOnlyRequest = (req: CorsfixRequest): boolean => {
+  if (!TEXT_ONLY_HOSTNAME) return false;
+  const host = req.header("host");
+  if (!host) return false;
+  // Strip port if present
+  const hostname = host.split(":")[0];
+  return hostname === TEXT_ONLY_HOSTNAME;
+};
+
 export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
   const origin_domain = req.ctx_origin_domain!;
   const target_domain = req.ctx_target_domain!;
   const apiKey = req.header("x-corsfix-key");
+
+  const textOnlyRequest = isTextOnlyRequest(req);
+  req.ctx_text_only = textOnlyRequest;
 
   let rateLimitConfig: RateLimitConfig;
 
@@ -69,6 +83,12 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       if (!product) {
         return sendCorsfixError(res, "invalid_subscription");
       }
+
+      const isTextOnlyPlan = !!product.textOnly;
+      if (textOnlyRequest !== isTextOnlyPlan) {
+        return sendCorsfixError(res, "plan_mismatch");
+      }
+
       rpm = getRpmByProductId(product.id);
     } else if (isTrialActive(user)) {
       rpm = trialLimit.rpm;

--- a/proxy/types/api.ts
+++ b/proxy/types/api.ts
@@ -9,6 +9,7 @@ export interface CorsfixRequest extends Request {
   ctx_user_id?: string;
   ctx_cache_duration?: number;
   ctx_api_key_request?: boolean;
+  ctx_text_only?: boolean;
   ctx_bytes?: number;
 }
 


### PR DESCRIPTION
- instead of relying on env variable, where we have to spin up 2 distinct servers
- we can rely on hostname (being the text only hostname) and plan config info telling itself is a text only