### PR TITLE
Add ALLOWED_ORIGINS env var to allowlist domains without app server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ DISABLE_SIGNUP=false
 # Rate limit (requests per minute) for self-hosted instances (default: 180)
 RPM=180
 
+ALLOWED_ORIGINS=
+ALLOWED_TARGETS=
+
 # Custom ports (optional, if 80/443 are already in use)
 HTTP_PORT=80
 HTTPS_PORT=443

--- a/prod.yaml
+++ b/prod.yaml
@@ -42,6 +42,8 @@ services:
       - REDIS_URI=redis://default:${REDIS_PASSWORD:-corsfix}@redis
       - KEK_VERSION_1=${KEK_VERSION_1}
       - APP_DOMAIN=${APP_DOMAIN}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
+      - ALLOWED_TARGETS=${ALLOWED_TARGETS:-}
   caddy:
     image: caddy:2-alpine
     restart: always

--- a/proxy/.env.example
+++ b/proxy/.env.example
@@ -6,3 +6,6 @@ KEK_VERSION_1=
 
 # Full domain for the app (e.g., app.example.com or admin-cors.example.com)
 APP_DOMAIN=app.localhost
+
+ALLOWED_ORIGINS=
+ALLOWED_TARGETS=

--- a/proxy/config/constants.ts
+++ b/proxy/config/constants.ts
@@ -26,3 +26,14 @@ export const SELFHOST_RPM = parseRPM(process.env.RPM);
 export const TEXT_ONLY_HOSTNAME = process.env.TEXT_ONLY_HOSTNAME;
 
 export const DEFAULT_PROXY_HOSTNAME = process.env.DEFAULT_PROXY_HOSTNAME;
+
+const parseDomainList = (value: string | undefined): string[] => {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((d) => d.trim())
+    .filter(Boolean);
+};
+
+export const ALLOWED_ORIGINS = parseDomainList(process.env.ALLOWED_ORIGINS);
+export const ALLOWED_TARGETS = parseDomainList(process.env.ALLOWED_TARGETS);

--- a/proxy/middleware/access.ts
+++ b/proxy/middleware/access.ts
@@ -9,7 +9,15 @@ import { CorsfixRequest, RateLimitConfig } from "../types/api";
 import { getApplication } from "../lib/services/applicationService";
 import { getUserByApiKey } from "../lib/services/apiKeyService";
 import { checkRateLimit } from "../lib/services/ratelimitService";
-import { DEFAULT_PROXY_HOSTNAME, IS_SELFHOST, SELFHOST_RPM, TEXT_ONLY_HOSTNAME, trialLimit } from "../config/constants";
+import {
+  ALLOWED_ORIGINS,
+  ALLOWED_TARGETS,
+  DEFAULT_PROXY_HOSTNAME,
+  IS_SELFHOST,
+  SELFHOST_RPM,
+  TEXT_ONLY_HOSTNAME,
+  trialLimit,
+} from "../config/constants";
 import { getUser } from "../lib/services/userService";
 import { getMonthToDateMetrics } from "../lib/services/metricService";
 import { getConfig } from "../lib/config";
@@ -30,6 +38,11 @@ const isDefaultProxy = (req: CorsfixRequest): boolean => {
   return getHostname(req) === DEFAULT_PROXY_HOSTNAME;
 };
 
+const isEnvAllowlisted = (origin_domain: string) =>
+  IS_SELFHOST &&
+  ALLOWED_ORIGINS.length > 0 &&
+  ALLOWED_ORIGINS.includes(origin_domain);
+
 export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
   const origin_domain = req.ctx_origin_domain!;
   const target_domain = req.ctx_target_domain!;
@@ -45,6 +58,19 @@ export const handleProxyAccess = async (req: CorsfixRequest, res: Response) => {
       key: req.header("x-real-ip") || req.ip,
       rpm: 60,
       local: true,
+    };
+  } else if (isEnvAllowlisted(origin_domain)) {
+    const allowedTargets =
+      ALLOWED_TARGETS.length > 0 ? ALLOWED_TARGETS : ["*"];
+    if (!isDomainAllowed(target_domain, allowedTargets)) {
+      return sendCorsfixError(res, "target_not_allowed", {
+        domain: target_domain,
+      });
+    }
+    req.ctx_user_id = "env-allowlist";
+    rateLimitConfig = {
+      key: req.header("x-real-ip") || req.ip,
+      rpm: SELFHOST_RPM,
     };
   } else {
     let user;


### PR DESCRIPTION
adds an `ALLOWED_ORIGINS` env var so self-hosted users can allowlist domains without running the dashboard.

closes #115